### PR TITLE
set default culture to en-US on client class initialization

### DIFF
--- a/PayWithAmazon/Client.cs
+++ b/PayWithAmazon/Client.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Xml.Serialization;
 using System.Collections.Generic;
 using System.Collections;
+using System.Threading;
 using System.Xml;
 using Newtonsoft.Json;
 using PayWithAmazon.StandardPaymentRequests;
@@ -45,6 +46,13 @@ namespace PayWithAmazon
         // Final URL to where the API parameters POST done,based off the config["region"] and respective mwsServiceUrls
         private string mwsServiceUrl = null;
 
+        private Client()
+        {
+            var ci = CultureInfo.GetCultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = ci;
+            Thread.CurrentThread.CurrentUICulture = ci;
+        }
+
         /// <summary>
         /// Takes the Configuration Object of the Configuration class
         /// </summary>
@@ -76,6 +84,7 @@ namespace PayWithAmazon
         ///  </code>
         /// </example>
         public Client(Configuration clientConfig)
+            : this()
         {
             if (clientConfig == null)
             {
@@ -91,6 +100,7 @@ namespace PayWithAmazon
         /// </summary>
         /// <param name="jsonFilePath"></param>
         public Client(string jsonFilePath)
+            : this()
         {
             string json;
             if (!string.IsNullOrEmpty(jsonFilePath))


### PR DESCRIPTION
This is an alternative solution for #5 issue:
On initialization of a `Client` object the default culture for the assembly Thread is set to `en-US` ([see also](http://stackoverflow.com/questions/13354211/how-to-set-default-culture-info-for-entire-c-sharp-application#13367456))

That's not a nice way of doing it - it would be better to fix all culture individual methods to [CultureInfo.InvariantCulture](https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.invariantculture%28v=vs.110%29.aspx). Or alternatively set the whole assembly culture to `en-US`. But unfortunately, it seems that there is no way of doing that via a `[assembly: ...]` attribute.