### PR TITLE
Sanitize raw strings

### DIFF
--- a/AmazonPay/IpnHandler.cs
+++ b/AmazonPay/IpnHandler.cs
@@ -156,7 +156,8 @@ namespace AmazonPay
 
             for (int i = 0; i < headers.Count; i++)
             {
-                sb.AppendLine("[Key: " + headers.GetKey(i) + ", Value: " + headers.GetValues(headers.GetKey(i))[0] + "]");
+                string key = headers.GetKey(i);
+                sb.AppendLine("[Key: " + key + ", Value: @#" + key +"#@" + headers.GetValues(headers.GetKey(i))[0] + "@#" + key +"#@]");
             }
             // Logging headers
             LogMessage(sb.ToString(), AmazonPay.SanitizeData.DataType.Text);

--- a/AmazonPay/SanitizeData.cs
+++ b/AmazonPay/SanitizeData.cs
@@ -110,7 +110,20 @@ namespace AmazonPay
             // Text Data Type
             else if (type == DataType.Text)
             {
-                returnString = data;
+                foreach (var item in sanitizeList)
+                {
+                    string maskedValue = "@#" + item + "#@";
+                    int startIndex = data.IndexOf(maskedValue);
+                    if (startIndex > 0)
+                    {
+                        int endIndex = data.LastIndexOf(maskedValue) + (maskedValue.Length);
+                        int length = endIndex - startIndex;
+                        string value = data.Substring(startIndex, length);
+                        data = data.Replace(value, REMOVED_TEXT);
+                    }
+                }
+                System.Text.RegularExpressions.Regex objRegEx = new System.Text.RegularExpressions.Regex("@#[^#@]*#@", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                returnString = objRegEx.Replace(data, ""); 
             }
             return returnString;
         }


### PR DESCRIPTION
In current master branch, AmazonPay/SanitizeData.cs  > SanitizeGivenData method was unable to sanitize Text data (type == DataType.Text)

So added feature to sanitize raw string data

AmazonPay/IpnHandler.cs > Added custom wrapper around value fields of NameValueCollection
AmazonPay/SanitizeData.cs > Detected and sanitized sensitive values and removed wrappers at last with RegEx


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
